### PR TITLE
Add php tag to enable syntax highlighting

### DIFF
--- a/1- Single Responsibility (S)/PHP/SRP-right-way.php
+++ b/1- Single Responsibility (S)/PHP/SRP-right-way.php
@@ -1,3 +1,5 @@
+<?php
+
 class Square
 {
     public $length;

--- a/1- Single Responsibility (S)/PHP/SRP-wrong-way.php
+++ b/1- Single Responsibility (S)/PHP/SRP-wrong-way.php
@@ -1,3 +1,5 @@
+<?php
+
 class Square
 {
     public $length;

--- a/2- Open-Closed (O)/PHP/OC-right-way.php
+++ b/2- Open-Closed (O)/PHP/OC-right-way.php
@@ -1,3 +1,5 @@
+<?php
+
 interface ShapeInterface
 {
     public function area();

--- a/2- Open-Closed (O)/PHP/OC-wrong-way.php
+++ b/2- Open-Closed (O)/PHP/OC-wrong-way.php
@@ -1,3 +1,5 @@
+<?php
+
 class Square
 {
     public $length;

--- a/2- Open-Closed (O)/PHP/readme.md
+++ b/2- Open-Closed (O)/PHP/readme.md
@@ -2,10 +2,10 @@
 
 Let’s revisit the AreaCalculator class and focus on the sum method:
 
-```
+```php
 class AreaCalculator
 {
-protected $shapes;
+    protected $shapes;
 
     public function __construct($shapes = [])
     {
@@ -34,10 +34,10 @@ A way you can make this sum method better is to remove the logic to calculate th
 
 Here is the area method defined in Square:
 
-```
+```php
 class Square
 {
-public $length;
+    public $length;
 
     public function __construct($length)
     {
@@ -54,10 +54,10 @@ public $length;
 
 And here is the area method defined in Circle:
 
-```
+```php
 class Circle
 {
-public $radius;
+    public $radius;
 
     public function construct($radius)
     {
@@ -74,7 +74,7 @@ public $radius;
 
 The sum method for AreaCalculator can then be rewritten as:
 
-```
+```php
 class AreaCalculator
 {
 // ...
@@ -99,10 +99,10 @@ Coding to an interface is an integral part of SOLID.
 
 Create a ShapeInterface that supports area:
 
-```
+```php
 interface ShapeInterface
 {
-public function area();
+    public function area();
 }
 ```
 
@@ -110,7 +110,7 @@ Modify your shape classes to implement the `ShapeInterface`.
 
 Here is the update to Square:
 
-```
+```php
 class Square implements ShapeInterface
 {
 // ...
@@ -119,7 +119,7 @@ class Square implements ShapeInterface
 
 And here is the update to Circle:
 
-```
+```php
 class Circle implements ShapeInterface
 {
 // ...
@@ -128,7 +128,7 @@ class Circle implements ShapeInterface
 
 In the sum method for AreaCalculator, you can check if the shapes provided are actually instances of the ShapeInterface; otherwise, throw an exception:
 
-```
+```php
 class AreaCalculator
 {
 // ...

--- a/3- Liskov Substitution (L)/PHP/LS-right-way.php
+++ b/3- Liskov Substitution (L)/PHP/LS-right-way.php
@@ -1,3 +1,5 @@
+<?php
+
 interface ShapeInterface
 {
     public function area();

--- a/3- Liskov Substitution (L)/PHP/LS-wrong-way.php
+++ b/3- Liskov Substitution (L)/PHP/LS-wrong-way.php
@@ -1,3 +1,5 @@
+<?php
+
 interface ShapeInterface
 {
     public function area();

--- a/3- Liskov Substitution (L)/PHP/readme.md
+++ b/3- Liskov Substitution (L)/PHP/readme.md
@@ -2,13 +2,13 @@
 
 Building off the example AreaCalculator class, consider a new VolumeCalculator class that extends the AreaCalculator class:
 
-```
+```php
 class VolumeCalculator extends AreaCalculator
 {
-public function construct($shapes = [])
+    public function construct($shapes = [])
     {
         parent::construct($shapes);
-}
+    }
 
     public function sum()
     {
@@ -21,9 +21,9 @@ public function construct($shapes = [])
 
 Recall that the `SumCalculatorOutputter` class resembles this:
 
-```
+```php
 class SumCalculatorOutputter {
-protected $calculator;
+    protected $calculator;
 
     public function __constructor(AreaCalculator $calculator) {
         $this->calculator = $calculator;
@@ -40,8 +40,8 @@ protected $calculator;
     public function HTML() {
         return implode('', array(
             '',
-                'Sum of the areas of provided shapes: ',
-                $this->calculator->sum(),
+            'Sum of the areas of provided shapes: ',
+            $this->calculator->sum(),
             ''
         ));
     }
@@ -51,7 +51,7 @@ protected $calculator;
 
 If you tried to run an example like this:
 
-```
+```php
 $areas = new AreaCalculator($shapes);
 $volumes = new VolumeCalculator($solidShapes);
 
@@ -63,13 +63,13 @@ When you call the HTML method on the $output2 object, you will get an E_NOTICE e
 
 To fix this, instead of returning an array from the VolumeCalculator class sum method, return $summedData:
 
-```
+```php
 class VolumeCalculator extends AreaCalculator
 {
-public function construct($shapes = [])
+    public function construct($shapes = [])
     {
         parent::construct($shapes);
-}
+    }
 
     public function sum()
     {

--- a/4- Interface Segregation (I)/PHP/IS-right-way.php
+++ b/4- Interface Segregation (I)/PHP/IS-right-way.php
@@ -1,3 +1,5 @@
+<?php
+
 interface ManageShapeInterface
 {
     public function calculate();

--- a/4- Interface Segregation (I)/PHP/IS-wrong-way.php
+++ b/4- Interface Segregation (I)/PHP/IS-wrong-way.php
@@ -1,3 +1,5 @@
+<?php
+
 interface ShapeInterface
 {
     public function area();

--- a/4- Interface Segregation (I)/PHP/readme.md
+++ b/4- Interface Segregation (I)/PHP/readme.md
@@ -4,7 +4,7 @@ Still building from the previous `ShapeInterface` example, you will need to supp
 
 Let’s consider what would happen if you were to modify the `ShapeInterface` to add another contract:
 
-```
+```php
 interface ShapeInterface
 {
     public function area();
@@ -17,7 +17,7 @@ Now, any shape you create must implement the volume method, but you know that sq
 
 This would violate the interface segregation principle. Instead, you could create another interface called `ThreeDimensionalShapeInterface` that has the volume contract and three-dimensional shapes can implement this interface:
 
-```
+```php
 interface ShapeInterface
 {
     public function area();
@@ -46,7 +46,7 @@ This is a much better approach, but a pitfall to watch out for is when type-hint
 
 This way, you can have a single API for managing the shapes:
 
-```
+```php
 interface ManageShapeInterface
 {
     public function calculate();

--- a/5- Dependency Inversion (D)/PHP/DI-right-way.php
+++ b/5- Dependency Inversion (D)/PHP/DI-right-way.php
@@ -1,3 +1,5 @@
+<?php
+
 interface DBConnectionInterface
 {
     public function connect();

--- a/5- Dependency Inversion (D)/PHP/DI-wrong-way.php
+++ b/5- Dependency Inversion (D)/PHP/DI-wrong-way.php
@@ -1,3 +1,5 @@
+<?php
+
 class MySQLConnection
 {
     public function connect()

--- a/5- Dependency Inversion (D)/PHP/readme.md
+++ b/5- Dependency Inversion (D)/PHP/readme.md
@@ -2,7 +2,7 @@
 
 Here is an example of a `PasswordReminder` that connects to a MySQL database:
 
-```
+```php
 class MySQLConnection
 {
     public function connect()
@@ -29,7 +29,7 @@ Later, if you were to change the database engine, you would also have to edit th
 
 The `PasswordReminder` class should not care what database your application uses. To address these issues, you can code to an interface since high-level and low-level modules should depend on abstraction:
 
-```
+```php
 interface DBConnectionInterface
 {
     public function connect();
@@ -38,7 +38,7 @@ interface DBConnectionInterface
 
 The interface has a connect method and the `MySQLConnection` class implements this interface. Also, instead of directly type-hinting `MySQLConnection` class in the constructor of the `PasswordReminder`, you instead type-hint the `DBConnectionInterface` and no matter the type of database your application uses, the `PasswordReminder` class can connect to the database without any problems and open-close principle is not violated.
 
-```
+```php
 class MySQLConnection implements DBConnectionInterface
 {
     public function connect()


### PR DESCRIPTION
This PR adds `<?php` to beginning of php file and adds `php` to markdown snippet. 
This will enable syntax highlighting for better readability.
